### PR TITLE
Upgrade ApsflyerLib version to 6.14.2

### DIFF
--- a/segment-appsflyer-ios.podspec
+++ b/segment-appsflyer-ios.podspec
@@ -1,5 +1,5 @@
 version_appsflyerLib = '6.14.2'
-version_plugin = '6.13.1'
+version_plugin = '6.14.0'
 
 Pod::Spec.new do |s|
   s.name             = "segment-appsflyer-ios"

--- a/segment-appsflyer-ios.podspec
+++ b/segment-appsflyer-ios.podspec
@@ -1,4 +1,4 @@
-version_appsflyerLib = '6.13.1'
+version_appsflyerLib = '6.14.2'
 version_plugin = '6.13.1'
 
 Pod::Spec.new do |s|

--- a/segment-appsflyer-ios.podspec
+++ b/segment-appsflyer-ios.podspec
@@ -1,5 +1,5 @@
 version_appsflyerLib = '6.14.2'
-version_plugin = '6.14.0'
+version_plugin = '6.14.2'
 
 Pod::Spec.new do |s|
   s.name             = "segment-appsflyer-ios"


### PR DESCRIPTION
Se incrementa la versión de la libreria de AppsFlyer 
Se iguala la versión del plugin para que la versión del plugin haga sentido con la version de la dependencia antes mencionada 